### PR TITLE
chore: use different port for e2e testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "lint": "next lint --max-warnings=0",
     "cypress": "cypress open",
     "cypress:headless": "cypress run",
-    "e2e": "start-server-and-test dev :3000 cypress",
-    "e2e:headless": "start-server-and-test dev :3000 cypress:headless"
+    "e2e": "start-server-and-test 'yarn dev --port 3003' :3003 cypress",
+    "e2e:headless": "start-server-and-test 'yarn dev --port 3003' :3003 cypress:headless"
   },
   "dependencies": {
     "@ircsignpost/signpost-base": "^4.2.0",


### PR DESCRIPTION
The new port doesn't conflict with the default `next dev` one (3000), which should streamline operations.